### PR TITLE
log: make logging output more clear

### DIFF
--- a/_example/runtime/command.go
+++ b/_example/runtime/command.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -85,10 +86,11 @@ func logCmd() *cobra.Command {
 			// Context logger
 			log.BgLogger().Info("-- context logger --")
 			ctx := log.WithKeyValue(context.Background(), "hello", "world")
-			log.Logger(ctx).Debug("debug")
-			log.Logger(ctx).Info("info")
-			log.Logger(ctx).Warn("warn")
-			log.Logger(ctx).Error("error")
+			zapFields := []zap.Field{zap.Duration("duration", 42*time.Second), zap.Time("date", time.Now())}
+			log.Logger(ctx).Debug("debug", zapFields...)
+			log.Logger(ctx).Info("info", zapFields...)
+			log.Logger(ctx).Warn("warn", zapFields...)
+			log.Logger(ctx).Error("error", zapFields...)
 
 			// Print errorw
 			log.BgLogger().Info("-- print errorw --")

--- a/log/config.go
+++ b/log/config.go
@@ -35,7 +35,6 @@ func DevelopmentAndTextConfig() Config {
 	if runtime.GOOS != "windows" {
 		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	}
-	config.DisableCaller = true
 	config.DisableStacktrace = true
 
 	return Config{ZapConfig: config, ZapLevel: zapcore.DebugLevel}
@@ -51,8 +50,12 @@ func ProductionAndTextConfig() Config {
 	config.DisableCaller = true
 	config.DisableStacktrace = true
 
-	// Disable time encoder
+	// Disable time key
 	config.EncoderConfig.TimeKey = ""
+
+	// Change time and duration encoder
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	config.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
 
 	return Config{ZapConfig: config, ZapLevel: zapcore.InfoLevel}
 }

--- a/log/init.go
+++ b/log/init.go
@@ -8,7 +8,7 @@ var bgLogger *Core
 func init() {
 	logLevels = NewLogLevels(zap.InfoLevel)
 
-	config := ProductionAndJSONConfig()
+	config := ProductionAndTextConfig()
 	BuildAndSetBgLogger(config)
 }
 


### PR DESCRIPTION
- Change text logging style.
- Use text logging style as the default.